### PR TITLE
Allow unmask return type to be specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymask",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Map sequential IDs or serial numbers to random-looking strings",
   "type": "module",
   "exports": {
@@ -18,7 +18,7 @@
   "scripts": {
     "lint": "eslint ./src/*.ts ./test/*.ts",
     "lint:fix": "eslint --fix ./src/*.ts ./test/*.ts",
-    "test": "TS_NODE_PROJECT=./tsconfig.test.json c8 mocha test",
+    "test": "TS_NODE_PROJECT=./test/tsconfig.json c8 mocha test",
     "build:clean": "rimraf build/* && rimraf dist/*",
     "build:tidy": "rimraf dist/build",
     "build:compile": "tsc",
@@ -50,20 +50,20 @@
   "bugs": "https://github.com/keymask/keymask-js/issues",
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.5",
-    "@types/mocha": "^10.0.4",
-    "@types/node": "^20.9.0",
-    "@typescript-eslint/eslint-plugin": "^6.10.0",
-    "@typescript-eslint/parser": "^6.10.0",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^20.9.5",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
     "c8": "^8.0.1",
-    "eslint": "^8.53.0",
-    "eslint-plugin-jsdoc": "^46.8.2",
+    "eslint": "^8.54.0",
+    "eslint-plugin-jsdoc": "^46.9.0",
     "mocha": "^10.2.0",
     "rimraf": "^5.0.5",
-    "rollup": "^4.3.0",
+    "rollup": "^4.5.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-dts": "^6.1.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,28 +3,28 @@ lockfileVersion: '6.0'
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.5
-    version: 11.1.5(rollup@4.3.0)(tslib@2.6.2)(typescript@5.2.2)
+    version: 11.1.5(rollup@4.5.1)(tslib@2.6.2)(typescript@5.3.2)
   '@types/mocha':
-    specifier: ^10.0.4
-    version: 10.0.4
+    specifier: ^10.0.6
+    version: 10.0.6
   '@types/node':
-    specifier: ^20.9.0
-    version: 20.9.0
+    specifier: ^20.9.5
+    version: 20.9.5
   '@typescript-eslint/eslint-plugin':
-    specifier: ^6.10.0
-    version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
+    specifier: ^6.12.0
+    version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.2)
   '@typescript-eslint/parser':
-    specifier: ^6.10.0
-    version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
+    specifier: ^6.12.0
+    version: 6.12.0(eslint@8.54.0)(typescript@5.3.2)
   c8:
     specifier: ^8.0.1
     version: 8.0.1
   eslint:
-    specifier: ^8.53.0
-    version: 8.53.0
+    specifier: ^8.54.0
+    version: 8.54.0
   eslint-plugin-jsdoc:
-    specifier: ^46.8.2
-    version: 46.8.2(eslint@8.53.0)
+    specifier: ^46.9.0
+    version: 46.9.0(eslint@8.54.0)
   mocha:
     specifier: ^10.2.0
     version: 10.2.0
@@ -32,23 +32,23 @@ devDependencies:
     specifier: ^5.0.5
     version: 5.0.5
   rollup:
-    specifier: ^4.3.0
-    version: 4.3.0
+    specifier: ^4.5.1
+    version: 4.5.1
   rollup-plugin-cleanup:
     specifier: ^3.2.1
-    version: 3.2.1(rollup@4.3.0)
+    version: 3.2.1(rollup@4.5.1)
   rollup-plugin-dts:
     specifier: ^6.1.0
-    version: 6.1.0(rollup@4.3.0)(typescript@5.2.2)
+    version: 6.1.0(rollup@4.5.1)(typescript@5.3.2)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@20.9.0)(typescript@5.2.2)
+    version: 10.9.1(@types/node@20.9.5)(typescript@5.3.2)
   tslib:
     specifier: ^2.6.2
     version: 2.6.2
   typescript:
-    specifier: ^5.2.2
-    version: 5.2.2
+    specifier: ^5.3.2
+    version: 5.3.2
 
 packages:
 
@@ -57,12 +57,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@babel/code-frame@7.22.13:
-    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
+  /@babel/code-frame@7.23.4:
+    resolution: {integrity: sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==}
     engines: {node: '>=6.9.0'}
     requiresBuild: true
     dependencies:
-      '@babel/highlight': 7.22.20
+      '@babel/highlight': 7.23.4
       chalk: 2.4.2
     dev: true
     optional: true
@@ -73,8 +73,8 @@ packages:
     dev: true
     optional: true
 
-  /@babel/highlight@7.22.20:
-    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
+  /@babel/highlight@7.23.4:
+    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
@@ -94,22 +94,22 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@es-joy/jsdoccomment@0.40.1:
-    resolution: {integrity: sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==}
+  /@es-joy/jsdoccomment@0.41.0:
+    resolution: {integrity: sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==}
     engines: {node: '>=16'}
     dependencies:
-      comment-parser: 1.4.0
+      comment-parser: 1.4.1
       esquery: 1.5.0
       jsdoc-type-pratt-parser: 4.0.0
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.53.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.54.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -126,7 +126,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.23.0
-      ignore: 5.2.4
+      ignore: 5.3.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -135,8 +135,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.53.0:
-    resolution: {integrity: sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==}
+  /@eslint/js@8.54.0:
+    resolution: {integrity: sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -228,7 +228,7 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/plugin-typescript@11.1.5(rollup@4.3.0)(tslib@2.6.2)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.5(rollup@4.5.1)(tslib@2.6.2)(typescript@5.3.2):
     resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -241,14 +241,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.3.0)
+      '@rollup/pluginutils': 5.0.5(rollup@4.5.1)
       resolve: 1.22.8
-      rollup: 4.3.0
+      rollup: 4.5.1
       tslib: 2.6.2
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
-  /@rollup/pluginutils@5.0.5(rollup@4.3.0):
+  /@rollup/pluginutils@5.0.5(rollup@4.5.1):
     resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -260,99 +260,99 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 4.3.0
+      rollup: 4.5.1
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.3.0:
-    resolution: {integrity: sha512-/4pns6BYi8MXdwnXM44yoGAcFYVHL/BYlB2q1HXZ6AzH++LaiEVWFpBWQ/glXhbMbv3E3o09igrHFbP/snhAvA==}
+  /@rollup/rollup-android-arm-eabi@4.5.1:
+    resolution: {integrity: sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.3.0:
-    resolution: {integrity: sha512-nLO/JsL9idr416vzi3lHm3Xm+QZh4qHij8k3Er13kZr5YhL7/+kBAx84kDmPc7HMexLmwisjDCeDIKNFp8mDlQ==}
+  /@rollup/rollup-android-arm64@4.5.1:
+    resolution: {integrity: sha512-n1bX+LCGlQVuPlCofO0zOKe1b2XkFozAVRoczT+yxWZPGnkEAKTTYVOGZz8N4sKuBnKMxDbfhUsB1uwYdup/sw==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.3.0:
-    resolution: {integrity: sha512-dGhVBlllt4iHwTGy21IEoMOTN5wZoid19zEIxsdY29xcEiOEHqzDa7Sqrkh5OE7LKCowL61eFJXxYe/+pYa7ZQ==}
+  /@rollup/rollup-darwin-arm64@4.5.1:
+    resolution: {integrity: sha512-QqJBumdvfBqBBmyGHlKxje+iowZwrHna7pokj/Go3dV1PJekSKfmjKrjKQ/e6ESTGhkfPNLq3VXdYLAc+UtAQw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.3.0:
-    resolution: {integrity: sha512-h8wRfHeLEbU3NzaP1Oku7BYXCJQiTRr+8U0lklyOQXxXiEpHLL8tk1hFl+tezoRKLcPJD7joKaK74ASsqt3Ekg==}
+  /@rollup/rollup-darwin-x64@4.5.1:
+    resolution: {integrity: sha512-RrkDNkR/P5AEQSPkxQPmd2ri8WTjSl0RYmuFOiEABkEY/FSg0a4riihWQGKDJ4LnV9gigWZlTMx2DtFGzUrYQw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.3.0:
-    resolution: {integrity: sha512-wP4VgR/gfV18sylTuym3sxRTkAgUR2vh6YLeX/GEznk5jCYcYSlx585XlcUcl0c8UffIZlRJ09raWSX3JDb4GA==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.5.1:
+    resolution: {integrity: sha512-ZFPxvUZmE+fkB/8D9y/SWl/XaDzNSaxd1TJUSE27XAKlRpQ2VNce/86bGd9mEUgL3qrvjJ9XTGwoX0BrJkYK/A==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.3.0:
-    resolution: {integrity: sha512-v/14JCYVkqRSJeQbxFx4oUkwVQQw6lFMN7bd4vuARBc3X2lmomkxBsc+BFiIDL/BK+CTx5AOh/k9XmqDnKWRVg==}
+  /@rollup/rollup-linux-arm64-gnu@4.5.1:
+    resolution: {integrity: sha512-FEuAjzVIld5WVhu+M2OewLmjmbXWd3q7Zcx+Rwy4QObQCqfblriDMMS7p7+pwgjZoo9BLkP3wa9uglQXzsB9ww==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.3.0:
-    resolution: {integrity: sha512-tNhfYqFH5OxtRzfkTOKdgFYlPSZnlDLNW4+leNEvQZhwTJxoTwsZAAhR97l3qVry/kkLyJPBK+Q8EAJLPinDIg==}
+  /@rollup/rollup-linux-arm64-musl@4.5.1:
+    resolution: {integrity: sha512-f5Gs8WQixqGRtI0Iq/cMqvFYmgFzMinuJO24KRfnv7Ohi/HQclwrBCYkzQu1XfLEEt3DZyvveq9HWo4bLJf1Lw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.3.0:
-    resolution: {integrity: sha512-pw77m8QywdsoFdFOgmc8roF1inBI0rciqzO8ffRUgLoq7+ee9o5eFqtEcS6hHOOplgifAUUisP8cAnwl9nUYPw==}
+  /@rollup/rollup-linux-x64-gnu@4.5.1:
+    resolution: {integrity: sha512-CWPkPGrFfN2vj3mw+S7A/4ZaU3rTV7AkXUr08W9lNP+UzOvKLVf34tWCqrKrfwQ0NTk5GFqUr2XGpeR2p6R4gw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.3.0:
-    resolution: {integrity: sha512-tJs7v2MnV2F8w6X1UpPHl/43OfxjUy9SuJ2ZPoxn79v9vYteChVYO/ueLHCpRMmyTUIVML3N9z4azl9ENH8Xxg==}
+  /@rollup/rollup-linux-x64-musl@4.5.1:
+    resolution: {integrity: sha512-ZRETMFA0uVukUC9u31Ed1nx++29073goCxZtmZARwk5aF/ltuENaeTtRVsSQzFlzdd4J6L3qUm+EW8cbGt0CKQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.3.0:
-    resolution: {integrity: sha512-OKGxp6kATQdTyI2DF+e9s+hB3/QZB45b6e+dzcfW1SUqiF6CviWyevhmT4USsMEdP3mlpC9zxLz3Oh+WaTMOSw==}
+  /@rollup/rollup-win32-arm64-msvc@4.5.1:
+    resolution: {integrity: sha512-ihqfNJNb2XtoZMSCPeoo0cYMgU04ksyFIoOw5S0JUVbOhafLot+KD82vpKXOurE2+9o/awrqIxku9MRR9hozHQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.3.0:
-    resolution: {integrity: sha512-DDZ5AH68JJ2ClQFEA1aNnfA7Ybqyeh0644rGbrLOdNehTmzfICHiWSn0OprzYi9HAshTPQvlwrM+bi2kuaIOjQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.5.1:
+    resolution: {integrity: sha512-zK9MRpC8946lQ9ypFn4gLpdwr5a01aQ/odiIJeL9EbgZDMgbZjjT/XzTqJvDfTmnE1kHdbG20sAeNlpc91/wbg==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.3.0:
-    resolution: {integrity: sha512-dMvGV8p92GQ8jhNlGIKpyhVZPzJlT258pPrM5q2F8lKcc9Iv9BbfdnhX1OfinYWnb9ms5zLw6MlaMnqLfUkKnQ==}
+  /@rollup/rollup-win32-x64-msvc@4.5.1:
+    resolution: {integrity: sha512-5I3Nz4Sb9TYOtkRwlH0ow+BhMH2vnh38tZ4J4mggE48M/YyJyp/0sPSxhw1UeS1+oBgQ8q7maFtSeKpeRJu41Q==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -387,22 +387,22 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
-  /@types/mocha@10.0.4:
-    resolution: {integrity: sha512-xKU7bUjiFTIttpWaIZ9qvgg+22O1nmbA+HRxdlR+u6TWsGfmFdXrheJoK4fFxrHNVIOBDvDNKZG+LYBpMHpX3w==}
+  /@types/mocha@10.0.6:
+    resolution: {integrity: sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==}
     dev: true
 
-  /@types/node@20.9.0:
-    resolution: {integrity: sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==}
+  /@types/node@20.9.5:
+    resolution: {integrity: sha512-Uq2xbNq0chGg+/WQEU0LJTSs/1nKxz6u1iemLcGomkSnKokbW1fbLqc3HOqCf2JP7KjlL4QkS7oZZTrOQHQYgQ==}
     dependencies:
       undici-types: 5.26.5
     dev: true
 
-  /@types/semver@7.5.5:
-    resolution: {integrity: sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==}
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==}
+  /@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
@@ -413,25 +413,25 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/scope-manager': 6.10.0
-      '@typescript-eslint/type-utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.10.0
+      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/type-utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.12.0
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.53.0
+      eslint: 8.54.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.10.0(eslint@8.53.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==}
+  /@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -440,27 +440,27 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.10.0
-      '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.10.0
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.12.0
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.53.0
-      typescript: 5.2.2
+      eslint: 8.54.0
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@6.10.0:
-    resolution: {integrity: sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==}
+  /@typescript-eslint/scope-manager@6.12.0:
+    resolution: {integrity: sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/visitor-keys': 6.10.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/visitor-keys': 6.12.0
     dev: true
 
-  /@typescript-eslint/type-utils@6.10.0(eslint@8.53.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==}
+  /@typescript-eslint/type-utils@6.12.0(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -469,23 +469,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.53.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      eslint: 8.54.0
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@6.10.0:
-    resolution: {integrity: sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==}
+  /@typescript-eslint/types@6.12.0:
+    resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.10.0(typescript@5.2.2):
-    resolution: {integrity: sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==}
+  /@typescript-eslint/typescript-estree@6.12.0(typescript@5.3.2):
+    resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -493,42 +493,42 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/visitor-keys': 6.10.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/visitor-keys': 6.12.0
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.0.3(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.10.0(eslint@8.53.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==}
+  /@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.5
-      '@typescript-eslint/scope-manager': 6.10.0
-      '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
-      eslint: 8.53.0
+      '@types/semver': 7.5.6
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
+      eslint: 8.54.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.10.0:
-    resolution: {integrity: sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==}
+  /@typescript-eslint/visitor-keys@6.12.0:
+    resolution: {integrity: sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.10.0
+      '@typescript-eslint/types': 6.12.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -677,7 +677,7 @@ packages:
       istanbul-reports: 3.1.6
       rimraf: 3.0.2
       test-exclude: 6.0.0
-      v8-to-istanbul: 9.1.3
+      v8-to-istanbul: 9.2.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
     dev: true
@@ -765,8 +765,8 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /comment-parser@1.4.0:
-    resolution: {integrity: sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==}
+  /comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
     engines: {node: '>= 12.0.0'}
     dev: true
 
@@ -865,18 +865,18 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-plugin-jsdoc@46.8.2(eslint@8.53.0):
-    resolution: {integrity: sha512-5TSnD018f3tUJNne4s4gDWQflbsgOycIKEUBoCLn6XtBMgNHxQFmV8vVxUtiPxAQq8lrX85OaSG/2gnctxw9uQ==}
+  /eslint-plugin-jsdoc@46.9.0(eslint@8.54.0):
+    resolution: {integrity: sha512-UQuEtbqLNkPf5Nr/6PPRCtr9xypXY+g8y/Q7gPa0YK7eDhh0y2lWprXRnaYbW7ACgIUvpDKy9X2bZqxtGzBG9Q==}
     engines: {node: '>=16'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@es-joy/jsdoccomment': 0.40.1
+      '@es-joy/jsdoccomment': 0.41.0
       are-docs-informative: 0.0.2
-      comment-parser: 1.4.0
+      comment-parser: 1.4.1
       debug: 4.3.4(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      eslint: 8.53.0
+      eslint: 8.54.0
       esquery: 1.5.0
       is-builtin-module: 3.2.1
       semver: 7.5.4
@@ -898,15 +898,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.53.0:
-    resolution: {integrity: sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==}
+  /eslint@8.54.0:
+    resolution: {integrity: sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@eslint-community/regexpp': 4.10.0
       '@eslint/eslintrc': 2.1.3
-      '@eslint/js': 8.53.0
+      '@eslint/js': 8.54.0
       '@humanwhocodes/config-array': 0.11.13
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -928,7 +928,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.23.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -1019,7 +1019,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.1.1
+      flat-cache: 3.2.0
     dev: true
 
   /fill-range@7.0.1:
@@ -1037,9 +1037,9 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /flat-cache@3.1.1:
-    resolution: {integrity: sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==}
-    engines: {node: '>=12.0.0'}
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flatted: 3.2.9
       keyv: 4.5.4
@@ -1154,7 +1154,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.2.4
+      ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -1190,8 +1190,8 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+  /ignore@5.3.0:
+    resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -1382,8 +1382,8 @@ packages:
       is-unicode-supported: 0.1.0
     dev: true
 
-  /lru-cache@10.0.1:
-    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
+  /lru-cache@10.1.0:
+    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
     dev: true
 
@@ -1569,7 +1569,7 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 10.0.1
+      lru-cache: 10.1.0
       minipass: 7.0.4
     dev: true
 
@@ -1654,18 +1654,18 @@ packages:
       glob: 10.3.10
     dev: true
 
-  /rollup-plugin-cleanup@3.2.1(rollup@4.3.0):
+  /rollup-plugin-cleanup@3.2.1(rollup@4.5.1):
     resolution: {integrity: sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==}
     engines: {node: ^10.14.2 || >=12.0.0}
     peerDependencies:
       rollup: '>=2.0'
     dependencies:
       js-cleanup: 1.2.0
-      rollup: 4.3.0
+      rollup: 4.5.1
       rollup-pluginutils: 2.8.2
     dev: true
 
-  /rollup-plugin-dts@6.1.0(rollup@4.3.0)(typescript@5.2.2):
+  /rollup-plugin-dts@6.1.0(rollup@4.5.1)(typescript@5.3.2):
     resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -1673,10 +1673,10 @@ packages:
       typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.5
-      rollup: 4.3.0
-      typescript: 5.2.2
+      rollup: 4.5.1
+      typescript: 5.3.2
     optionalDependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.4
     dev: true
 
   /rollup-pluginutils@2.8.2:
@@ -1685,23 +1685,23 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup@4.3.0:
-    resolution: {integrity: sha512-scIi1NrKLDIYSPK66jjECtII7vIgdAMFmFo8h6qm++I6nN9qDSV35Ku6erzGVqYjx+lj+j5wkusRMr++8SyDZg==}
+  /rollup@4.5.1:
+    resolution: {integrity: sha512-0EQribZoPKpb5z1NW/QYm3XSR//Xr8BeEXU49Lc/mQmpmVVG5jPUVrpc2iptup/0WMrY9mzas0fxH+TjYvG2CA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.3.0
-      '@rollup/rollup-android-arm64': 4.3.0
-      '@rollup/rollup-darwin-arm64': 4.3.0
-      '@rollup/rollup-darwin-x64': 4.3.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.3.0
-      '@rollup/rollup-linux-arm64-gnu': 4.3.0
-      '@rollup/rollup-linux-arm64-musl': 4.3.0
-      '@rollup/rollup-linux-x64-gnu': 4.3.0
-      '@rollup/rollup-linux-x64-musl': 4.3.0
-      '@rollup/rollup-win32-arm64-msvc': 4.3.0
-      '@rollup/rollup-win32-ia32-msvc': 4.3.0
-      '@rollup/rollup-win32-x64-msvc': 4.3.0
+      '@rollup/rollup-android-arm-eabi': 4.5.1
+      '@rollup/rollup-android-arm64': 4.5.1
+      '@rollup/rollup-darwin-arm64': 4.5.1
+      '@rollup/rollup-darwin-x64': 4.5.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.5.1
+      '@rollup/rollup-linux-arm64-gnu': 4.5.1
+      '@rollup/rollup-linux-arm64-musl': 4.5.1
+      '@rollup/rollup-linux-x64-gnu': 4.5.1
+      '@rollup/rollup-linux-x64-musl': 4.5.1
+      '@rollup/rollup-win32-arm64-msvc': 4.5.1
+      '@rollup/rollup-win32-ia32-msvc': 4.5.1
+      '@rollup/rollup-win32-x64-msvc': 4.5.1
       fsevents: 2.3.3
     dev: true
 
@@ -1864,16 +1864,16 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.2.2):
+  /ts-api-utils@1.0.3(typescript@5.3.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.9.0)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -1892,14 +1892,14 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.9.0
+      '@types/node': 20.9.5
       acorn: 8.11.2
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.2.2
+      typescript: 5.3.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -1920,8 +1920,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1940,8 +1940,8 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
-  /v8-to-istanbul@9.1.3:
-    resolution: {integrity: sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==}
+  /v8-to-istanbul@9.2.0:
+    resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20

--- a/src/bufferUtils.ts
+++ b/src/bufferUtils.ts
@@ -44,3 +44,18 @@ export function toBigInt(data: DataView): bigint {
   }
   return n;
 }
+
+/**
+ * Convert a numeric value to an ArrayBuffer.
+ * @param {number | bigint} value The value to convert.
+ * @returns {ArrayBuffer} The converted value.
+ */
+export function toBuffer(value: number | bigint): ArrayBuffer {
+  if (typeof value === "number") {
+    value = BigInt(value);
+  }
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setBigUint64(0, value, true);
+  return buffer;
+}

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -100,90 +100,90 @@ describe("Keymask", () => {
   });
 
   describe("Bigint output", () => {
-    const keymask = new Keymask({ bigint: true });
+    const keymask = new Keymask();
 
     it("should mask and unmask in range 1", () => {
       equal(keymask.mask(1n), "c");
       equal(keymask.mask(40n), "Y");
-      equal(keymask.unmask("c"), 1n);
-      equal(keymask.unmask("Y"), 40n);
+      equal(keymask.unmask("c", "bigint"), 1n);
+      equal(keymask.unmask("Y", "bigint"), 40n);
     });
 
     it("should mask and unmask in range 2", () => {
       equal(keymask.mask(41n), "PK");
       equal(keymask.mask(1020n), "sV");
-      equal(keymask.unmask("PK"), 41n);
-      equal(keymask.unmask("sV"), 1020n);
+      equal(keymask.unmask("PK", "bigint"), 41n);
+      equal(keymask.unmask("sV", "bigint"), 1020n);
     });
 
     it("should mask and unmask in range 3", () => {
       equal(keymask.mask(1021n), "Lfc");
       equal(keymask.mask(65520n), "dhk");
-      equal(keymask.unmask("Lfc"), 1021n);
-      equal(keymask.unmask("dhk"), 65520n);
+      equal(keymask.unmask("Lfc", "bigint"), 1021n);
+      equal(keymask.unmask("dhk", "bigint"), 65520n);
     });
 
     it("should mask and unmask in range 4", () => {
       equal(keymask.mask(65521n), "NcPL");
       equal(keymask.mask(2097142n), "NzPT");
-      equal(keymask.unmask("NcPL"), 65521n);
-      equal(keymask.unmask("NzPT"), 2097142n);
+      equal(keymask.unmask("NcPL", "bigint"), 65521n);
+      equal(keymask.unmask("NzPT", "bigint"), 2097142n);
     });
 
     it("should mask and unmask in range 5", () => {
       equal(keymask.mask(2097143n), "bWGJC");
       equal(keymask.mask(67108858n), "dnBsV");
-      equal(keymask.unmask("bWGJC"), 2097143n);
-      equal(keymask.unmask("dnBsV"), 67108858n);
+      equal(keymask.unmask("bWGJC", "bigint"), 2097143n);
+      equal(keymask.unmask("dnBsV", "bigint"), 67108858n);
     });
 
     it("should mask and unmask in range 6", () => {
       equal(keymask.mask(67108859n), "WkCBvr");
       equal(keymask.mask(4294967290n), "mSJnSd");
-      equal(keymask.unmask("WkCBvr"), 67108859n);
-      equal(keymask.unmask("mSJnSd"), 4294967290n);
+      equal(keymask.unmask("WkCBvr", "bigint"), 67108859n);
+      equal(keymask.unmask("mSJnSd", "bigint"), 4294967290n);
     });
 
     it("should mask and unmask in range 7", () => {
       equal(keymask.mask(4294967291n), "ncbyPTV");
       equal(keymask.mask(137438953446n), "mGJFsQc");
-      equal(keymask.unmask("ncbyPTV"), 4294967291n);
-      equal(keymask.unmask("mGJFsQc"), 137438953446n);
+      equal(keymask.unmask("ncbyPTV", "bigint"), 4294967291n);
+      equal(keymask.unmask("mGJFsQc", "bigint"), 137438953446n);
     });
 
     it("should mask and unmask in range 8", () => {
       equal(keymask.mask(137438953447n), "vwmKZxKZ");
       equal(keymask.mask(4398046511092n), "GwdjRScK");
-      equal(keymask.unmask("vwmKZxKZ"), 137438953447n);
-      equal(keymask.unmask("GwdjRScK"), 4398046511092n);
+      equal(keymask.unmask("vwmKZxKZ", "bigint"), 137438953447n);
+      equal(keymask.unmask("GwdjRScK", "bigint"), 4398046511092n);
     });
 
     it("should mask and unmask in range 9", () => {
       equal(keymask.mask(4398046511093n), "gqFHjWmxF");
       equal(keymask.mask(281474976710596n), "wZVHVzvrj");
-      equal(keymask.unmask("gqFHjWmxF"), 4398046511093n);
-      equal(keymask.unmask("wZVHVzvrj"), 281474976710596n);
+      equal(keymask.unmask("gqFHjWmxF", "bigint"), 4398046511093n);
+      equal(keymask.unmask("wZVHVzvrj", "bigint"), 281474976710596n);
     });
 
     it("should mask and unmask in range 10", () => {
       equal(keymask.mask(281474976710597n), "nWRWYwnkhD");
       equal(keymask.mask(9007199254740880n), "KdCvLBSKJb");
-      equal(keymask.unmask("nWRWYwnkhD"), 281474976710597n);
-      equal(keymask.unmask("KdCvLBSKJb"), 9007199254740880n);
+      equal(keymask.unmask("nWRWYwnkhD", "bigint"), 281474976710597n);
+      equal(keymask.unmask("KdCvLBSKJb", "bigint"), 9007199254740880n);
     });
 
     it("should mask and unmask in range 11", () => {
       equal(keymask.mask(9007199254740881n), "NjQkwmfKKVP");
       equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
-      equal(keymask.unmask("NjQkwmfKKVP"), 9007199254740881n);
-      equal(keymask.unmask("TQmxMJKgrNW"), 288230376151711716n);
+      equal(keymask.unmask("NjQkwmfKKVP", "bigint"), 9007199254740881n);
+      equal(keymask.unmask("TQmxMJKgrNW", "bigint"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
       equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
       equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
-      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
-      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
+      equal(keymask.unmask("DjfkCZLtcBLn", "bigint"), 288230376151711717n);
+      equal(keymask.unmask("YcWfgzxKYXFW", "bigint"), 18446744073709551556n);
     });
 
     it("should process binary data", () => {
@@ -191,8 +191,153 @@ describe("Keymask", () => {
       const buffer2 = new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer;
       equal(keymask.mask(buffer1), "NpRcJcFtscDkjdfXLfFWGtqR");
       equal(keymask.mask(buffer2), "HXmKjxGXGXBKTD");
-      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR"), 21345817372864405881847059188222722561n);
-      deepEqual(keymask.unmask("HXmKjxGXGXBKTD"), 1832590477950520989195n);
+      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR", "bigint"), 21345817372864405881847059188222722561n);
+      deepEqual(keymask.unmask("HXmKjxGXGXBKTD", "bigint"), 1832590477950520989195n);
+    });
+  });
+
+  describe("ArrayBuffer output", () => {
+    const keymask = new Keymask();
+
+    it("should mask and unmask in range 1", () => {
+      const buffer1 = new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([40, 0, 0, 0, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(1n), "c");
+      equal(keymask.mask(40n), "Y");
+      equal(keymask.mask(buffer1), "c");
+      equal(keymask.mask(buffer2), "Y");
+      deepEqual(keymask.unmask("c", "buffer"), buffer1);
+      deepEqual(keymask.unmask("Y", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 2", () => {
+      const buffer1 = new Uint8Array([41, 0, 0, 0, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([252, 3, 0, 0, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(41n), "PK");
+      equal(keymask.mask(1020n), "sV");
+      equal(keymask.mask(buffer1), "PK");
+      equal(keymask.mask(buffer2), "sV");
+      deepEqual(keymask.unmask("PK", "buffer"), buffer1);
+      deepEqual(keymask.unmask("sV", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 3", () => {
+      const buffer1 = new Uint8Array([253, 3, 0, 0, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([240, 255, 0, 0, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(1021n), "Lfc");
+      equal(keymask.mask(65520n), "dhk");
+      equal(keymask.mask(buffer1), "Lfc");
+      equal(keymask.mask(buffer2), "dhk");
+      deepEqual(keymask.unmask("Lfc", "buffer"), buffer1);
+      deepEqual(keymask.unmask("dhk", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 4", () => {
+      const buffer1 = new Uint8Array([241, 255, 0, 0, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([246, 255, 31, 0, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(65521n), "NcPL");
+      equal(keymask.mask(2097142n), "NzPT");
+      equal(keymask.mask(buffer1), "NcPL");
+      equal(keymask.mask(buffer2), "NzPT");
+      deepEqual(keymask.unmask("NcPL", "buffer"), buffer1);
+      deepEqual(keymask.unmask("NzPT", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 5", () => {
+      const buffer1 = new Uint8Array([247, 255, 31, 0, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([250, 255, 255, 3, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(2097143n), "bWGJC");
+      equal(keymask.mask(67108858n), "dnBsV");
+      equal(keymask.mask(buffer1), "bWGJC");
+      equal(keymask.mask(buffer2), "dnBsV");
+      deepEqual(keymask.unmask("bWGJC", "buffer"), buffer1);
+      deepEqual(keymask.unmask("dnBsV", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 6", () => {
+      const buffer1 = new Uint8Array([251, 255, 255, 3, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([250, 255, 255, 255, 0, 0, 0, 0]).buffer;
+      equal(keymask.mask(67108859n), "WkCBvr");
+      equal(keymask.mask(4294967290n), "mSJnSd");
+      equal(keymask.mask(buffer1), "WkCBvr");
+      equal(keymask.mask(buffer2), "mSJnSd");
+      deepEqual(keymask.unmask("WkCBvr", "buffer"), buffer1);
+      deepEqual(keymask.unmask("mSJnSd", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 7", () => {
+      const buffer1 = new Uint8Array([251, 255, 255, 255, 0, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([230, 255, 255, 255, 31, 0, 0, 0]).buffer;
+      equal(keymask.mask(4294967291n), "ncbyPTV");
+      equal(keymask.mask(137438953446n), "mGJFsQc");
+      equal(keymask.mask(buffer1), "ncbyPTV");
+      equal(keymask.mask(buffer2), "mGJFsQc");
+      deepEqual(keymask.unmask("ncbyPTV", "buffer"), buffer1);
+      deepEqual(keymask.unmask("mGJFsQc", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 8", () => {
+      const buffer1 = new Uint8Array([231, 255, 255, 255, 31, 0, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([244, 255, 255, 255, 255, 3, 0, 0]).buffer;
+      equal(keymask.mask(137438953447n), "vwmKZxKZ");
+      equal(keymask.mask(4398046511092n), "GwdjRScK");
+      equal(keymask.mask(buffer1), "vwmKZxKZ");
+      equal(keymask.mask(buffer2), "GwdjRScK");
+      deepEqual(keymask.unmask("vwmKZxKZ", "buffer"), buffer1);
+      deepEqual(keymask.unmask("GwdjRScK", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 9", () => {
+      const buffer1 = new Uint8Array([245, 255, 255, 255, 255, 3, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([196, 255, 255, 255, 255, 255, 0, 0]).buffer;
+      equal(keymask.mask(4398046511093n), "gqFHjWmxF");
+      equal(keymask.mask(281474976710596n), "wZVHVzvrj");
+      equal(keymask.mask(buffer1), "gqFHjWmxF");
+      equal(keymask.mask(buffer2), "wZVHVzvrj");
+      deepEqual(keymask.unmask("gqFHjWmxF", "buffer"), buffer1);
+      deepEqual(keymask.unmask("wZVHVzvrj", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 10", () => {
+      const buffer1 = new Uint8Array([197, 255, 255, 255, 255, 255, 0, 0]).buffer;
+      const buffer2 = new Uint8Array([144, 255, 255, 255, 255, 255, 31, 0]).buffer;
+      equal(keymask.mask(281474976710597n), "nWRWYwnkhD");
+      equal(keymask.mask(9007199254740880n), "KdCvLBSKJb");
+      equal(keymask.mask(buffer1), "nWRWYwnkhD");
+      equal(keymask.mask(buffer2), "KdCvLBSKJb");
+      deepEqual(keymask.unmask("nWRWYwnkhD", "buffer"), buffer1);
+      deepEqual(keymask.unmask("KdCvLBSKJb", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 11", () => {
+      const buffer1 = new Uint8Array([145, 255, 255, 255, 255, 255, 31, 0]).buffer;
+      const buffer2 = new Uint8Array([228, 255, 255, 255, 255, 255, 255, 3]).buffer;
+      equal(keymask.mask(9007199254740881n), "NjQkwmfKKVP");
+      equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
+      equal(keymask.mask(buffer1), "NjQkwmfKKVP");
+      equal(keymask.mask(buffer2), "TQmxMJKgrNW");
+      deepEqual(keymask.unmask("NjQkwmfKKVP", "buffer"), buffer1);
+      deepEqual(keymask.unmask("TQmxMJKgrNW", "buffer"), buffer2);
+    });
+
+    it("should mask and unmask in range 12", () => {
+      const buffer1 = new Uint8Array([229, 255, 255, 255, 255, 255, 255, 3]).buffer;
+      const buffer2 = new Uint8Array([196, 255, 255, 255, 255, 255, 255, 255]).buffer;
+      equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
+      equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
+      equal(keymask.mask(buffer1), "DjfkCZLtcBLn");
+      equal(keymask.mask(buffer2), "YcWfgzxKYXFW");
+      deepEqual(keymask.unmask("DjfkCZLtcBLn", "buffer"), buffer1);
+      deepEqual(keymask.unmask("YcWfgzxKYXFW", "buffer"), buffer2);
+    });
+
+    it("should process binary data", () => {
+      const buffer1 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).buffer;
+      const buffer2 = new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer;
+      equal(keymask.mask(buffer1), "NpRcJcFtscDkjdfXLfFWGtqR");
+      equal(keymask.mask(buffer2), "HXmKjxGXGXBKTD");
+      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR", "buffer"), buffer1);
+      deepEqual(keymask.unmask("HXmKjxGXGXBKTD", "buffer"), buffer2);
     });
   });
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,9 +7,8 @@
     "lib": ["es2022"],                            
     "strict": true,  
     "esModuleInterop": false,
-    "rootDir": "./",
+    "rootDir": "../",
     "types": ["mocha", "node"]
-  }
-  ,
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  },
+  "include": ["**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "rootDir": "./src",
     "outDir": "./build",
     "declaration": true
-  }
-  ,
+  },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Remove `bigint` option from `KeymaskOptions`.

Replace it with a `type` parameter on the `unmask()` function. This allows type-safe conversion of the result to a specified type (rather than always returning a union type).

Add the ability to unmask to an `ArrayBuffer` even with values less than 64 bits.

Update dependencies and README, bump version.

Fix issues with 'node' and 'mocha' type definitions in unit tests.