### PR TITLE
Move type parameter to the class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymask",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Map sequential IDs or serial numbers to random-looking strings",
   "type": "module",
   "exports": {
@@ -27,7 +27,10 @@
   },
   "keywords": [
     "LCG",
+    "MLCG",
+    "multiplicative",
     "linear congruential generator",
+    "random",
     "base41",
     "string",
     "character",
@@ -51,15 +54,15 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.9.5",
-    "@typescript-eslint/eslint-plugin": "^6.12.0",
-    "@typescript-eslint/parser": "^6.12.0",
+    "@types/node": "^20.10.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1",
     "c8": "^8.0.1",
     "eslint": "^8.54.0",
     "eslint-plugin-jsdoc": "^46.9.0",
     "mocha": "^10.2.0",
     "rimraf": "^5.0.5",
-    "rollup": "^4.5.1",
+    "rollup": "^4.6.0",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-dts": "^6.1.0",
     "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,19 +3,19 @@ lockfileVersion: '6.0'
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.5
-    version: 11.1.5(rollup@4.5.1)(tslib@2.6.2)(typescript@5.3.2)
+    version: 11.1.5(rollup@4.6.0)(tslib@2.6.2)(typescript@5.3.2)
   '@types/mocha':
     specifier: ^10.0.6
     version: 10.0.6
   '@types/node':
-    specifier: ^20.9.5
-    version: 20.9.5
+    specifier: ^20.10.0
+    version: 20.10.0
   '@typescript-eslint/eslint-plugin':
-    specifier: ^6.12.0
-    version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.2)
+    specifier: ^6.13.1
+    version: 6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.3.2)
   '@typescript-eslint/parser':
-    specifier: ^6.12.0
-    version: 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+    specifier: ^6.13.1
+    version: 6.13.1(eslint@8.54.0)(typescript@5.3.2)
   c8:
     specifier: ^8.0.1
     version: 8.0.1
@@ -32,17 +32,17 @@ devDependencies:
     specifier: ^5.0.5
     version: 5.0.5
   rollup:
-    specifier: ^4.5.1
-    version: 4.5.1
+    specifier: ^4.6.0
+    version: 4.6.0
   rollup-plugin-cleanup:
     specifier: ^3.2.1
-    version: 3.2.1(rollup@4.5.1)
+    version: 3.2.1(rollup@4.6.0)
   rollup-plugin-dts:
     specifier: ^6.1.0
-    version: 6.1.0(rollup@4.5.1)(typescript@5.3.2)
+    version: 6.1.0(rollup@4.6.0)(typescript@5.3.2)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@20.9.5)(typescript@5.3.2)
+    version: 10.9.1(@types/node@20.10.0)(typescript@5.3.2)
   tslib:
     specifier: ^2.6.2
     version: 2.6.2
@@ -228,7 +228,7 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/plugin-typescript@11.1.5(rollup@4.5.1)(tslib@2.6.2)(typescript@5.3.2):
+  /@rollup/plugin-typescript@11.1.5(rollup@4.6.0)(tslib@2.6.2)(typescript@5.3.2):
     resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -241,15 +241,15 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.5.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.6.0)
       resolve: 1.22.8
-      rollup: 4.5.1
+      rollup: 4.6.0
       tslib: 2.6.2
       typescript: 5.3.2
     dev: true
 
-  /@rollup/pluginutils@5.0.5(rollup@4.5.1):
-    resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
+  /@rollup/pluginutils@5.1.0(rollup@4.6.0):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -260,99 +260,99 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 4.5.1
+      rollup: 4.6.0
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.5.1:
-    resolution: {integrity: sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==}
+  /@rollup/rollup-android-arm-eabi@4.6.0:
+    resolution: {integrity: sha512-keHkkWAe7OtdALGoutLY3utvthkGF+Y17ws9LYT8pxMBYXaCoH/8dXS2uzo6e8+sEhY7y/zi5RFo22Dy2lFpDw==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.5.1:
-    resolution: {integrity: sha512-n1bX+LCGlQVuPlCofO0zOKe1b2XkFozAVRoczT+yxWZPGnkEAKTTYVOGZz8N4sKuBnKMxDbfhUsB1uwYdup/sw==}
+  /@rollup/rollup-android-arm64@4.6.0:
+    resolution: {integrity: sha512-y3Kt+34smKQNWilicPbBz/MXEY7QwDzMFNgwEWeYiOhUt9MTWKjHqe3EVkXwT2fR7izOvHpDWZ0o2IyD9SWX7A==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.5.1:
-    resolution: {integrity: sha512-QqJBumdvfBqBBmyGHlKxje+iowZwrHna7pokj/Go3dV1PJekSKfmjKrjKQ/e6ESTGhkfPNLq3VXdYLAc+UtAQw==}
+  /@rollup/rollup-darwin-arm64@4.6.0:
+    resolution: {integrity: sha512-oLzzxcUIHltHxOCmaXl+pkIlU+uhSxef5HfntW7RsLh1eHm+vJzjD9Oo4oUKso4YuP4PpbFJNlZjJuOrxo8dPg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.5.1:
-    resolution: {integrity: sha512-RrkDNkR/P5AEQSPkxQPmd2ri8WTjSl0RYmuFOiEABkEY/FSg0a4riihWQGKDJ4LnV9gigWZlTMx2DtFGzUrYQw==}
+  /@rollup/rollup-darwin-x64@4.6.0:
+    resolution: {integrity: sha512-+ANnmjkcOBaV25n0+M0Bere3roeVAnwlKW65qagtuAfIxXF9YxUneRyAn/RDcIdRa7QrjRNJL3jR7T43ObGe8Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.5.1:
-    resolution: {integrity: sha512-ZFPxvUZmE+fkB/8D9y/SWl/XaDzNSaxd1TJUSE27XAKlRpQ2VNce/86bGd9mEUgL3qrvjJ9XTGwoX0BrJkYK/A==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.6.0:
+    resolution: {integrity: sha512-tBTSIkjSVUyrekddpkAqKOosnj1Fc0ZY0rJL2bIEWPKqlEQk0paORL9pUIlt7lcGJi3LzMIlUGXvtNi1Z6MOCQ==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.5.1:
-    resolution: {integrity: sha512-FEuAjzVIld5WVhu+M2OewLmjmbXWd3q7Zcx+Rwy4QObQCqfblriDMMS7p7+pwgjZoo9BLkP3wa9uglQXzsB9ww==}
+  /@rollup/rollup-linux-arm64-gnu@4.6.0:
+    resolution: {integrity: sha512-Ed8uJI3kM11de9S0j67wAV07JUNhbAqIrDYhQBrQW42jGopgheyk/cdcshgGO4fW5Wjq97COCY/BHogdGvKVNQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.5.1:
-    resolution: {integrity: sha512-f5Gs8WQixqGRtI0Iq/cMqvFYmgFzMinuJO24KRfnv7Ohi/HQclwrBCYkzQu1XfLEEt3DZyvveq9HWo4bLJf1Lw==}
+  /@rollup/rollup-linux-arm64-musl@4.6.0:
+    resolution: {integrity: sha512-mZoNQ/qK4D7SSY8v6kEsAAyDgznzLLuSFCA3aBHZTmf3HP/dW4tNLTtWh9+LfyO0Z1aUn+ecpT7IQ3WtIg3ViQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.5.1:
-    resolution: {integrity: sha512-CWPkPGrFfN2vj3mw+S7A/4ZaU3rTV7AkXUr08W9lNP+UzOvKLVf34tWCqrKrfwQ0NTk5GFqUr2XGpeR2p6R4gw==}
+  /@rollup/rollup-linux-x64-gnu@4.6.0:
+    resolution: {integrity: sha512-rouezFHpwCqdEXsqAfNsTgSWO0FoZ5hKv5p+TGO5KFhyN/dvYXNMqMolOb8BkyKcPqjYRBeT+Z6V3aM26rPaYg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.5.1:
-    resolution: {integrity: sha512-ZRETMFA0uVukUC9u31Ed1nx++29073goCxZtmZARwk5aF/ltuENaeTtRVsSQzFlzdd4J6L3qUm+EW8cbGt0CKQ==}
+  /@rollup/rollup-linux-x64-musl@4.6.0:
+    resolution: {integrity: sha512-Bbm+fyn3S6u51urfj3YnqBXg5vI2jQPncRRELaucmhBVyZkbWClQ1fEsRmdnCPpQOQfkpg9gZArvtMVkOMsh1w==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.5.1:
-    resolution: {integrity: sha512-ihqfNJNb2XtoZMSCPeoo0cYMgU04ksyFIoOw5S0JUVbOhafLot+KD82vpKXOurE2+9o/awrqIxku9MRR9hozHQ==}
+  /@rollup/rollup-win32-arm64-msvc@4.6.0:
+    resolution: {integrity: sha512-+MRMcyx9L2kTrTUzYmR61+XVsliMG4odFb5UmqtiT8xOfEicfYAGEuF/D1Pww1+uZkYhBqAHpvju7VN+GnC3ng==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.5.1:
-    resolution: {integrity: sha512-zK9MRpC8946lQ9ypFn4gLpdwr5a01aQ/odiIJeL9EbgZDMgbZjjT/XzTqJvDfTmnE1kHdbG20sAeNlpc91/wbg==}
+  /@rollup/rollup-win32-ia32-msvc@4.6.0:
+    resolution: {integrity: sha512-rxfeE6K6s/Xl2HGeK6cO8SiQq3k/3BYpw7cfhW5Bk2euXNEpuzi2cc7llxx1si1QgwfjNtdRNTGqdBzGlFZGFw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.5.1:
-    resolution: {integrity: sha512-5I3Nz4Sb9TYOtkRwlH0ow+BhMH2vnh38tZ4J4mggE48M/YyJyp/0sPSxhw1UeS1+oBgQ8q7maFtSeKpeRJu41Q==}
+  /@rollup/rollup-win32-x64-msvc@4.6.0:
+    resolution: {integrity: sha512-QqmCsydHS172Y0Kc13bkMXvipbJSvzeglBncJG3LsYJSiPlxYACz7MmJBs4A8l1oU+jfhYEIC/+AUSlvjmiX/g==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -391,8 +391,8 @@ packages:
     resolution: {integrity: sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==}
     dev: true
 
-  /@types/node@20.9.5:
-    resolution: {integrity: sha512-Uq2xbNq0chGg+/WQEU0LJTSs/1nKxz6u1iemLcGomkSnKokbW1fbLqc3HOqCf2JP7KjlL4QkS7oZZTrOQHQYgQ==}
+  /@types/node@20.10.0:
+    resolution: {integrity: sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -401,8 +401,8 @@ packages:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.2):
-    resolution: {integrity: sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==}
+  /@typescript-eslint/eslint-plugin@6.13.1(@typescript-eslint/parser@6.13.1)(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
@@ -413,11 +413,11 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
-      '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/type-utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
-      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/parser': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/type-utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.54.0
       graphemer: 1.4.0
@@ -430,8 +430,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.3.2):
-    resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
+  /@typescript-eslint/parser@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -440,10 +440,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.54.0
       typescript: 5.3.2
@@ -451,16 +451,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@6.12.0:
-    resolution: {integrity: sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==}
+  /@typescript-eslint/scope-manager@6.13.1:
+    resolution: {integrity: sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/visitor-keys': 6.13.1
     dev: true
 
-  /@typescript-eslint/type-utils@6.12.0(eslint@8.54.0)(typescript@5.3.2):
-    resolution: {integrity: sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==}
+  /@typescript-eslint/type-utils@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -469,8 +469,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
-      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
+      '@typescript-eslint/utils': 6.13.1(eslint@8.54.0)(typescript@5.3.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.54.0
       ts-api-utils: 1.0.3(typescript@5.3.2)
@@ -479,13 +479,13 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@6.12.0:
-    resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
+  /@typescript-eslint/types@6.13.1:
+    resolution: {integrity: sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.12.0(typescript@5.3.2):
-    resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
+  /@typescript-eslint/typescript-estree@6.13.1(typescript@5.3.2):
+    resolution: {integrity: sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -493,8 +493,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/visitor-keys': 6.13.1
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
@@ -505,8 +505,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.3.2):
-    resolution: {integrity: sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==}
+  /@typescript-eslint/utils@6.13.1(eslint@8.54.0)(typescript@5.3.2):
+    resolution: {integrity: sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -514,9 +514,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
-      '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
+      '@typescript-eslint/scope-manager': 6.13.1
+      '@typescript-eslint/types': 6.13.1
+      '@typescript-eslint/typescript-estree': 6.13.1(typescript@5.3.2)
       eslint: 8.54.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -524,11 +524,11 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.12.0:
-    resolution: {integrity: sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==}
+  /@typescript-eslint/visitor-keys@6.13.1:
+    resolution: {integrity: sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/types': 6.13.1
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -1654,18 +1654,18 @@ packages:
       glob: 10.3.10
     dev: true
 
-  /rollup-plugin-cleanup@3.2.1(rollup@4.5.1):
+  /rollup-plugin-cleanup@3.2.1(rollup@4.6.0):
     resolution: {integrity: sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==}
     engines: {node: ^10.14.2 || >=12.0.0}
     peerDependencies:
       rollup: '>=2.0'
     dependencies:
       js-cleanup: 1.2.0
-      rollup: 4.5.1
+      rollup: 4.6.0
       rollup-pluginutils: 2.8.2
     dev: true
 
-  /rollup-plugin-dts@6.1.0(rollup@4.5.1)(typescript@5.3.2):
+  /rollup-plugin-dts@6.1.0(rollup@4.6.0)(typescript@5.3.2):
     resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -1673,7 +1673,7 @@ packages:
       typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.5
-      rollup: 4.5.1
+      rollup: 4.6.0
       typescript: 5.3.2
     optionalDependencies:
       '@babel/code-frame': 7.23.4
@@ -1685,23 +1685,23 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup@4.5.1:
-    resolution: {integrity: sha512-0EQribZoPKpb5z1NW/QYm3XSR//Xr8BeEXU49Lc/mQmpmVVG5jPUVrpc2iptup/0WMrY9mzas0fxH+TjYvG2CA==}
+  /rollup@4.6.0:
+    resolution: {integrity: sha512-R8i5Her4oO1LiMQ3jKf7MUglYV/mhQ5g5OKeld5CnkmPdIGo79FDDQYqPhq/PCVuTQVuxsWgIbDy9F+zdHn80w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.5.1
-      '@rollup/rollup-android-arm64': 4.5.1
-      '@rollup/rollup-darwin-arm64': 4.5.1
-      '@rollup/rollup-darwin-x64': 4.5.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.5.1
-      '@rollup/rollup-linux-arm64-gnu': 4.5.1
-      '@rollup/rollup-linux-arm64-musl': 4.5.1
-      '@rollup/rollup-linux-x64-gnu': 4.5.1
-      '@rollup/rollup-linux-x64-musl': 4.5.1
-      '@rollup/rollup-win32-arm64-msvc': 4.5.1
-      '@rollup/rollup-win32-ia32-msvc': 4.5.1
-      '@rollup/rollup-win32-x64-msvc': 4.5.1
+      '@rollup/rollup-android-arm-eabi': 4.6.0
+      '@rollup/rollup-android-arm64': 4.6.0
+      '@rollup/rollup-darwin-arm64': 4.6.0
+      '@rollup/rollup-darwin-x64': 4.6.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.6.0
+      '@rollup/rollup-linux-arm64-gnu': 4.6.0
+      '@rollup/rollup-linux-arm64-musl': 4.6.0
+      '@rollup/rollup-linux-x64-gnu': 4.6.0
+      '@rollup/rollup-linux-x64-musl': 4.6.0
+      '@rollup/rollup-win32-arm64-msvc': 4.6.0
+      '@rollup/rollup-win32-ia32-msvc': 4.6.0
+      '@rollup/rollup-win32-x64-msvc': 4.6.0
       fsevents: 2.3.3
     dev: true
 
@@ -1873,7 +1873,7 @@ packages:
       typescript: 5.3.2
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.2):
+  /ts-node@10.9.1(@types/node@20.10.0)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -1892,7 +1892,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.9.5
+      '@types/node': 20.10.0
       acorn: 8.11.2
       acorn-walk: 8.3.0
       arg: 4.1.3

--- a/test/Keymask.test.ts
+++ b/test/Keymask.test.ts
@@ -99,91 +99,91 @@ describe("Keymask", () => {
     });
   });
 
-  describe("Bigint output", () => {
-    const keymask = new Keymask();
+  describe("Integer output", () => {
+    const keymask = new Keymask({ type: "integer" });
 
     it("should mask and unmask in range 1", () => {
-      equal(keymask.mask(1n), "c");
-      equal(keymask.mask(40n), "Y");
-      equal(keymask.unmask("c", "bigint"), 1n);
-      equal(keymask.unmask("Y", "bigint"), 40n);
+      equal(keymask.mask(1), "c");
+      equal(keymask.mask(40), "Y");
+      equal(keymask.unmask("c"), 1);
+      equal(keymask.unmask("Y"), 40);
     });
 
     it("should mask and unmask in range 2", () => {
-      equal(keymask.mask(41n), "PK");
-      equal(keymask.mask(1020n), "sV");
-      equal(keymask.unmask("PK", "bigint"), 41n);
-      equal(keymask.unmask("sV", "bigint"), 1020n);
+      equal(keymask.mask(41), "PK");
+      equal(keymask.mask(1020), "sV");
+      equal(keymask.unmask("PK"), 41);
+      equal(keymask.unmask("sV"), 1020);
     });
 
     it("should mask and unmask in range 3", () => {
-      equal(keymask.mask(1021n), "Lfc");
-      equal(keymask.mask(65520n), "dhk");
-      equal(keymask.unmask("Lfc", "bigint"), 1021n);
-      equal(keymask.unmask("dhk", "bigint"), 65520n);
+      equal(keymask.mask(1021), "Lfc");
+      equal(keymask.mask(65520), "dhk");
+      equal(keymask.unmask("Lfc"), 1021);
+      equal(keymask.unmask("dhk"), 65520);
     });
 
     it("should mask and unmask in range 4", () => {
-      equal(keymask.mask(65521n), "NcPL");
-      equal(keymask.mask(2097142n), "NzPT");
-      equal(keymask.unmask("NcPL", "bigint"), 65521n);
-      equal(keymask.unmask("NzPT", "bigint"), 2097142n);
+      equal(keymask.mask(65521), "NcPL");
+      equal(keymask.mask(2097142), "NzPT");
+      equal(keymask.unmask("NcPL"), 65521);
+      equal(keymask.unmask("NzPT"), 2097142);
     });
 
     it("should mask and unmask in range 5", () => {
-      equal(keymask.mask(2097143n), "bWGJC");
-      equal(keymask.mask(67108858n), "dnBsV");
-      equal(keymask.unmask("bWGJC", "bigint"), 2097143n);
-      equal(keymask.unmask("dnBsV", "bigint"), 67108858n);
+      equal(keymask.mask(2097143), "bWGJC");
+      equal(keymask.mask(67108858), "dnBsV");
+      equal(keymask.unmask("bWGJC"), 2097143);
+      equal(keymask.unmask("dnBsV"), 67108858);
     });
 
     it("should mask and unmask in range 6", () => {
-      equal(keymask.mask(67108859n), "WkCBvr");
-      equal(keymask.mask(4294967290n), "mSJnSd");
-      equal(keymask.unmask("WkCBvr", "bigint"), 67108859n);
-      equal(keymask.unmask("mSJnSd", "bigint"), 4294967290n);
+      equal(keymask.mask(67108859), "WkCBvr");
+      equal(keymask.mask(4294967290), "mSJnSd");
+      equal(keymask.unmask("WkCBvr"), 67108859);
+      equal(keymask.unmask("mSJnSd"), 4294967290);
     });
 
     it("should mask and unmask in range 7", () => {
-      equal(keymask.mask(4294967291n), "ncbyPTV");
-      equal(keymask.mask(137438953446n), "mGJFsQc");
-      equal(keymask.unmask("ncbyPTV", "bigint"), 4294967291n);
-      equal(keymask.unmask("mGJFsQc", "bigint"), 137438953446n);
+      equal(keymask.mask(4294967291), "ncbyPTV");
+      equal(keymask.mask(137438953446), "mGJFsQc");
+      equal(keymask.unmask("ncbyPTV"), 4294967291);
+      equal(keymask.unmask("mGJFsQc"), 137438953446);
     });
 
     it("should mask and unmask in range 8", () => {
-      equal(keymask.mask(137438953447n), "vwmKZxKZ");
-      equal(keymask.mask(4398046511092n), "GwdjRScK");
-      equal(keymask.unmask("vwmKZxKZ", "bigint"), 137438953447n);
-      equal(keymask.unmask("GwdjRScK", "bigint"), 4398046511092n);
+      equal(keymask.mask(137438953447), "vwmKZxKZ");
+      equal(keymask.mask(4398046511092), "GwdjRScK");
+      equal(keymask.unmask("vwmKZxKZ"), 137438953447);
+      equal(keymask.unmask("GwdjRScK"), 4398046511092);
     });
 
     it("should mask and unmask in range 9", () => {
-      equal(keymask.mask(4398046511093n), "gqFHjWmxF");
-      equal(keymask.mask(281474976710596n), "wZVHVzvrj");
-      equal(keymask.unmask("gqFHjWmxF", "bigint"), 4398046511093n);
-      equal(keymask.unmask("wZVHVzvrj", "bigint"), 281474976710596n);
+      equal(keymask.mask(4398046511093), "gqFHjWmxF");
+      equal(keymask.mask(281474976710596), "wZVHVzvrj");
+      equal(keymask.unmask("gqFHjWmxF"), 4398046511093);
+      equal(keymask.unmask("wZVHVzvrj"), 281474976710596);
     });
 
     it("should mask and unmask in range 10", () => {
-      equal(keymask.mask(281474976710597n), "nWRWYwnkhD");
-      equal(keymask.mask(9007199254740880n), "KdCvLBSKJb");
-      equal(keymask.unmask("nWRWYwnkhD", "bigint"), 281474976710597n);
-      equal(keymask.unmask("KdCvLBSKJb", "bigint"), 9007199254740880n);
+      equal(keymask.mask(281474976710597), "nWRWYwnkhD");
+      equal(keymask.mask(9007199254740880), "KdCvLBSKJb");
+      equal(keymask.unmask("nWRWYwnkhD"), 281474976710597);
+      equal(keymask.unmask("KdCvLBSKJb"), 9007199254740880);
     });
 
     it("should mask and unmask in range 11", () => {
       equal(keymask.mask(9007199254740881n), "NjQkwmfKKVP");
       equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
-      equal(keymask.unmask("NjQkwmfKKVP", "bigint"), 9007199254740881n);
-      equal(keymask.unmask("TQmxMJKgrNW", "bigint"), 288230376151711716n);
+      equal(keymask.unmask("NjQkwmfKKVP"), 9007199254740881n);
+      equal(keymask.unmask("TQmxMJKgrNW"), 288230376151711716n);
     });
 
     it("should mask and unmask in range 12", () => {
       equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
       equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
-      equal(keymask.unmask("DjfkCZLtcBLn", "bigint"), 288230376151711717n);
-      equal(keymask.unmask("YcWfgzxKYXFW", "bigint"), 18446744073709551556n);
+      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
+      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
     });
 
     it("should process binary data", () => {
@@ -191,13 +191,110 @@ describe("Keymask", () => {
       const buffer2 = new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer;
       equal(keymask.mask(buffer1), "NpRcJcFtscDkjdfXLfFWGtqR");
       equal(keymask.mask(buffer2), "HXmKjxGXGXBKTD");
-      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR", "bigint"), 21345817372864405881847059188222722561n);
-      deepEqual(keymask.unmask("HXmKjxGXGXBKTD", "bigint"), 1832590477950520989195n);
+      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR"), 21345817372864405881847059188222722561n);
+      deepEqual(keymask.unmask("HXmKjxGXGXBKTD"), 1832590477950520989195n);
+    });
+  });
+
+  describe("Bigint output", () => {
+    const keymask = new Keymask({ type: "bigint" });
+
+    it("should mask and unmask in range 1", () => {
+      equal(keymask.mask(1n), "c");
+      equal(keymask.mask(40n), "Y");
+      equal(keymask.unmask("c"), 1n);
+      equal(keymask.unmask("Y"), 40n);
+    });
+
+    it("should mask and unmask in range 2", () => {
+      equal(keymask.mask(41n), "PK");
+      equal(keymask.mask(1020n), "sV");
+      equal(keymask.unmask("PK"), 41n);
+      equal(keymask.unmask("sV"), 1020n);
+    });
+
+    it("should mask and unmask in range 3", () => {
+      equal(keymask.mask(1021n), "Lfc");
+      equal(keymask.mask(65520n), "dhk");
+      equal(keymask.unmask("Lfc"), 1021n);
+      equal(keymask.unmask("dhk"), 65520n);
+    });
+
+    it("should mask and unmask in range 4", () => {
+      equal(keymask.mask(65521n), "NcPL");
+      equal(keymask.mask(2097142n), "NzPT");
+      equal(keymask.unmask("NcPL"), 65521n);
+      equal(keymask.unmask("NzPT"), 2097142n);
+    });
+
+    it("should mask and unmask in range 5", () => {
+      equal(keymask.mask(2097143n), "bWGJC");
+      equal(keymask.mask(67108858n), "dnBsV");
+      equal(keymask.unmask("bWGJC"), 2097143n);
+      equal(keymask.unmask("dnBsV"), 67108858n);
+    });
+
+    it("should mask and unmask in range 6", () => {
+      equal(keymask.mask(67108859n), "WkCBvr");
+      equal(keymask.mask(4294967290n), "mSJnSd");
+      equal(keymask.unmask("WkCBvr"), 67108859n);
+      equal(keymask.unmask("mSJnSd"), 4294967290n);
+    });
+
+    it("should mask and unmask in range 7", () => {
+      equal(keymask.mask(4294967291n), "ncbyPTV");
+      equal(keymask.mask(137438953446n), "mGJFsQc");
+      equal(keymask.unmask("ncbyPTV"), 4294967291n);
+      equal(keymask.unmask("mGJFsQc"), 137438953446n);
+    });
+
+    it("should mask and unmask in range 8", () => {
+      equal(keymask.mask(137438953447n), "vwmKZxKZ");
+      equal(keymask.mask(4398046511092n), "GwdjRScK");
+      equal(keymask.unmask("vwmKZxKZ"), 137438953447n);
+      equal(keymask.unmask("GwdjRScK"), 4398046511092n);
+    });
+
+    it("should mask and unmask in range 9", () => {
+      equal(keymask.mask(4398046511093n), "gqFHjWmxF");
+      equal(keymask.mask(281474976710596n), "wZVHVzvrj");
+      equal(keymask.unmask("gqFHjWmxF"), 4398046511093n);
+      equal(keymask.unmask("wZVHVzvrj"), 281474976710596n);
+    });
+
+    it("should mask and unmask in range 10", () => {
+      equal(keymask.mask(281474976710597n), "nWRWYwnkhD");
+      equal(keymask.mask(9007199254740880n), "KdCvLBSKJb");
+      equal(keymask.unmask("nWRWYwnkhD"), 281474976710597n);
+      equal(keymask.unmask("KdCvLBSKJb"), 9007199254740880n);
+    });
+
+    it("should mask and unmask in range 11", () => {
+      equal(keymask.mask(9007199254740881n), "NjQkwmfKKVP");
+      equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
+      equal(keymask.unmask("NjQkwmfKKVP"), 9007199254740881n);
+      equal(keymask.unmask("TQmxMJKgrNW"), 288230376151711716n);
+    });
+
+    it("should mask and unmask in range 12", () => {
+      equal(keymask.mask(288230376151711717n), "DjfkCZLtcBLn");
+      equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
+      equal(keymask.unmask("DjfkCZLtcBLn"), 288230376151711717n);
+      equal(keymask.unmask("YcWfgzxKYXFW"), 18446744073709551556n);
+    });
+
+    it("should process binary data", () => {
+      const buffer1 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).buffer;
+      const buffer2 = new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer;
+      equal(keymask.mask(buffer1), "NpRcJcFtscDkjdfXLfFWGtqR");
+      equal(keymask.mask(buffer2), "HXmKjxGXGXBKTD");
+      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR"), 21345817372864405881847059188222722561n);
+      deepEqual(keymask.unmask("HXmKjxGXGXBKTD"), 1832590477950520989195n);
     });
   });
 
   describe("ArrayBuffer output", () => {
-    const keymask = new Keymask();
+    const keymask = new Keymask({type: "buffer"});
 
     it("should mask and unmask in range 1", () => {
       const buffer1 = new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]).buffer;
@@ -206,8 +303,8 @@ describe("Keymask", () => {
       equal(keymask.mask(40n), "Y");
       equal(keymask.mask(buffer1), "c");
       equal(keymask.mask(buffer2), "Y");
-      deepEqual(keymask.unmask("c", "buffer"), buffer1);
-      deepEqual(keymask.unmask("Y", "buffer"), buffer2);
+      deepEqual(keymask.unmask("c"), buffer1);
+      deepEqual(keymask.unmask("Y"), buffer2);
     });
 
     it("should mask and unmask in range 2", () => {
@@ -217,8 +314,8 @@ describe("Keymask", () => {
       equal(keymask.mask(1020n), "sV");
       equal(keymask.mask(buffer1), "PK");
       equal(keymask.mask(buffer2), "sV");
-      deepEqual(keymask.unmask("PK", "buffer"), buffer1);
-      deepEqual(keymask.unmask("sV", "buffer"), buffer2);
+      deepEqual(keymask.unmask("PK"), buffer1);
+      deepEqual(keymask.unmask("sV"), buffer2);
     });
 
     it("should mask and unmask in range 3", () => {
@@ -228,8 +325,8 @@ describe("Keymask", () => {
       equal(keymask.mask(65520n), "dhk");
       equal(keymask.mask(buffer1), "Lfc");
       equal(keymask.mask(buffer2), "dhk");
-      deepEqual(keymask.unmask("Lfc", "buffer"), buffer1);
-      deepEqual(keymask.unmask("dhk", "buffer"), buffer2);
+      deepEqual(keymask.unmask("Lfc"), buffer1);
+      deepEqual(keymask.unmask("dhk"), buffer2);
     });
 
     it("should mask and unmask in range 4", () => {
@@ -239,8 +336,8 @@ describe("Keymask", () => {
       equal(keymask.mask(2097142n), "NzPT");
       equal(keymask.mask(buffer1), "NcPL");
       equal(keymask.mask(buffer2), "NzPT");
-      deepEqual(keymask.unmask("NcPL", "buffer"), buffer1);
-      deepEqual(keymask.unmask("NzPT", "buffer"), buffer2);
+      deepEqual(keymask.unmask("NcPL"), buffer1);
+      deepEqual(keymask.unmask("NzPT"), buffer2);
     });
 
     it("should mask and unmask in range 5", () => {
@@ -250,8 +347,8 @@ describe("Keymask", () => {
       equal(keymask.mask(67108858n), "dnBsV");
       equal(keymask.mask(buffer1), "bWGJC");
       equal(keymask.mask(buffer2), "dnBsV");
-      deepEqual(keymask.unmask("bWGJC", "buffer"), buffer1);
-      deepEqual(keymask.unmask("dnBsV", "buffer"), buffer2);
+      deepEqual(keymask.unmask("bWGJC"), buffer1);
+      deepEqual(keymask.unmask("dnBsV"), buffer2);
     });
 
     it("should mask and unmask in range 6", () => {
@@ -261,8 +358,8 @@ describe("Keymask", () => {
       equal(keymask.mask(4294967290n), "mSJnSd");
       equal(keymask.mask(buffer1), "WkCBvr");
       equal(keymask.mask(buffer2), "mSJnSd");
-      deepEqual(keymask.unmask("WkCBvr", "buffer"), buffer1);
-      deepEqual(keymask.unmask("mSJnSd", "buffer"), buffer2);
+      deepEqual(keymask.unmask("WkCBvr"), buffer1);
+      deepEqual(keymask.unmask("mSJnSd"), buffer2);
     });
 
     it("should mask and unmask in range 7", () => {
@@ -272,8 +369,8 @@ describe("Keymask", () => {
       equal(keymask.mask(137438953446n), "mGJFsQc");
       equal(keymask.mask(buffer1), "ncbyPTV");
       equal(keymask.mask(buffer2), "mGJFsQc");
-      deepEqual(keymask.unmask("ncbyPTV", "buffer"), buffer1);
-      deepEqual(keymask.unmask("mGJFsQc", "buffer"), buffer2);
+      deepEqual(keymask.unmask("ncbyPTV"), buffer1);
+      deepEqual(keymask.unmask("mGJFsQc"), buffer2);
     });
 
     it("should mask and unmask in range 8", () => {
@@ -283,8 +380,8 @@ describe("Keymask", () => {
       equal(keymask.mask(4398046511092n), "GwdjRScK");
       equal(keymask.mask(buffer1), "vwmKZxKZ");
       equal(keymask.mask(buffer2), "GwdjRScK");
-      deepEqual(keymask.unmask("vwmKZxKZ", "buffer"), buffer1);
-      deepEqual(keymask.unmask("GwdjRScK", "buffer"), buffer2);
+      deepEqual(keymask.unmask("vwmKZxKZ"), buffer1);
+      deepEqual(keymask.unmask("GwdjRScK"), buffer2);
     });
 
     it("should mask and unmask in range 9", () => {
@@ -294,8 +391,8 @@ describe("Keymask", () => {
       equal(keymask.mask(281474976710596n), "wZVHVzvrj");
       equal(keymask.mask(buffer1), "gqFHjWmxF");
       equal(keymask.mask(buffer2), "wZVHVzvrj");
-      deepEqual(keymask.unmask("gqFHjWmxF", "buffer"), buffer1);
-      deepEqual(keymask.unmask("wZVHVzvrj", "buffer"), buffer2);
+      deepEqual(keymask.unmask("gqFHjWmxF"), buffer1);
+      deepEqual(keymask.unmask("wZVHVzvrj"), buffer2);
     });
 
     it("should mask and unmask in range 10", () => {
@@ -305,8 +402,8 @@ describe("Keymask", () => {
       equal(keymask.mask(9007199254740880n), "KdCvLBSKJb");
       equal(keymask.mask(buffer1), "nWRWYwnkhD");
       equal(keymask.mask(buffer2), "KdCvLBSKJb");
-      deepEqual(keymask.unmask("nWRWYwnkhD", "buffer"), buffer1);
-      deepEqual(keymask.unmask("KdCvLBSKJb", "buffer"), buffer2);
+      deepEqual(keymask.unmask("nWRWYwnkhD"), buffer1);
+      deepEqual(keymask.unmask("KdCvLBSKJb"), buffer2);
     });
 
     it("should mask and unmask in range 11", () => {
@@ -316,8 +413,8 @@ describe("Keymask", () => {
       equal(keymask.mask(288230376151711716n), "TQmxMJKgrNW");
       equal(keymask.mask(buffer1), "NjQkwmfKKVP");
       equal(keymask.mask(buffer2), "TQmxMJKgrNW");
-      deepEqual(keymask.unmask("NjQkwmfKKVP", "buffer"), buffer1);
-      deepEqual(keymask.unmask("TQmxMJKgrNW", "buffer"), buffer2);
+      deepEqual(keymask.unmask("NjQkwmfKKVP"), buffer1);
+      deepEqual(keymask.unmask("TQmxMJKgrNW"), buffer2);
     });
 
     it("should mask and unmask in range 12", () => {
@@ -327,8 +424,8 @@ describe("Keymask", () => {
       equal(keymask.mask(18446744073709551556n), "YcWfgzxKYXFW");
       equal(keymask.mask(buffer1), "DjfkCZLtcBLn");
       equal(keymask.mask(buffer2), "YcWfgzxKYXFW");
-      deepEqual(keymask.unmask("DjfkCZLtcBLn", "buffer"), buffer1);
-      deepEqual(keymask.unmask("YcWfgzxKYXFW", "buffer"), buffer2);
+      deepEqual(keymask.unmask("DjfkCZLtcBLn"), buffer1);
+      deepEqual(keymask.unmask("YcWfgzxKYXFW"), buffer2);
     });
 
     it("should process binary data", () => {
@@ -336,8 +433,8 @@ describe("Keymask", () => {
       const buffer2 = new Uint8Array([11, 22, 33, 44, 55, 66, 77, 88, 99]).buffer;
       equal(keymask.mask(buffer1), "NpRcJcFtscDkjdfXLfFWGtqR");
       equal(keymask.mask(buffer2), "HXmKjxGXGXBKTD");
-      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR", "buffer"), buffer1);
-      deepEqual(keymask.unmask("HXmKjxGXGXBKTD", "buffer"), buffer2);
+      deepEqual(keymask.unmask("NpRcJcFtscDkjdfXLfFWGtqR"), buffer1);
+      deepEqual(keymask.unmask("HXmKjxGXGXBKTD"), buffer2);
     });
   });
 


### PR DESCRIPTION
Move type parameter to the class (remove type parameter from the `unmask` function).

Add `integer` type as an option (returns `number | bigint`).

Update unit tests and dependencies.